### PR TITLE
Use versionlock for upgrades

### DIFF
--- a/roles/vpac/tasks/kernelrt.yaml
+++ b/roles/vpac/tasks/kernelrt.yaml
@@ -18,6 +18,18 @@
     - kernel-rt-kvm
     - tuned-profiles-nfv-host
     - realtime-tests
+    - dnf-plugins-core
+    - python3-dnf-plugin-versionlock
 
 - name: Set default kernel as RT
   ansible.builtin.shell: grubby --set-default-index 0
+
+- name: Versionlock on kernel
+  community.general.dnf_versionlock:
+    name: kernel
+    state: present
+
+- name: UN-Versionlock on kernel-rt
+  community.general.dnf_versionlock:
+    name: kernel-rt
+    state: absent


### PR DESCRIPTION
Uses DNF versionlock to hold kernel packages but allowing kernel-rt ones