### PR TITLE
Extend versionlock

### DIFF
--- a/roles/vpac/tasks/kernelrt.yaml
+++ b/roles/vpac/tasks/kernelrt.yaml
@@ -26,8 +26,12 @@
 
 - name: Versionlock on kernel
   community.general.dnf_versionlock:
-    name: kernel
+    name: "{{ item }}"
     state: present
+  with_items:
+    - kernel
+    - kernel-core
+    - kernel-modules
 
 - name: UN-Versionlock on kernel-rt
   community.general.dnf_versionlock:


### PR DESCRIPTION
Kernel-core and other packages were left out and seems that ansible blocks when using 'kernel*' (probably because number of matches in regexp)